### PR TITLE
Fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ WebContainer API is perfect for building interactive coding experiences. Among i
 
 ## How To
 
-For an up-to-date documentation, please refer to [our documentation](https://webcontainers.io).
+For up-to-date documentation, please refer to [our documentation](https://webcontainers.io).
 
 ## Cross-Origin Isolation
 


### PR DESCRIPTION
## Summary
- fix phrasing for documentation link in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6854be5d17e48325a21e926b7db1cfbd